### PR TITLE
Fixed typos from AWS_ACCES_KEY_ID to AWS_ACCESS_KEY_ID

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Apply Terraform
         env:
-          AWS_ACCES_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
+          AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_db_password: ${{ secrets.TF_VAR_DB_PASSWORD }}
           TF_VAR_django_secret_key: ${{ secrets.TF_VAR_DJANGO_SECRET_KEY }}


### PR DESCRIPTION
Fixed typos from AWS_ACCES_KEY_ID to AWS_ACCESS_KEY_ID in `Apply Terraform`  job.